### PR TITLE
Allow other module names

### DIFF
--- a/tools/decodeCrashDump.sh
+++ b/tools/decodeCrashDump.sh
@@ -1,15 +1,18 @@
 #!/bin/bash
 
 DUMPFILE="$1"
+MODULENAME="${2:-QGC-Gov}"  # Use second argument if provided; else default to "QGC-Gov"
+
 TOOLSDIR=$(dirname "$0")
 SYMSDIR=$TOOLSDIR/../syms
 OUTPUTFILE=$(dirname "$DUMPFILE")/$(basename "$DUMPFILE" .dmp).txt
-MODULENAME="QGC-Gov" # Generic name
 
 $TOOLSDIR/minidump_stackwalk -s -c "$DUMPFILE" "$SYMSDIR" 2>/dev/null > "$OUTPUTFILE"
 
 if grep -q "No symbols, .*$MODULENAME.*" "$OUTPUTFILE"; then
     MODULEID=$(grep -P "No symbols, .*$MODULENAME.*" "$OUTPUTFILE" | grep -Po "[0-9A-F]{33}")
     echo "WARNING: No debug symbols found for $MODULENAME with module-id $MODULEID"
+elif ! grep -q "$MODULENAME\b" "$OUTPUTFILE"; then
+    echo "WARNING: No module named $MODULENAME found in the dump file. Please pass the correct module name as the second argument."
 fi
 

--- a/tools/decodeCrashDump.sh
+++ b/tools/decodeCrashDump.sh
@@ -9,7 +9,7 @@ MODULENAME="QGC-Gov" # Generic name
 $TOOLSDIR/minidump_stackwalk -s -c "$DUMPFILE" "$SYMSDIR" 2>/dev/null > "$OUTPUTFILE"
 
 if grep -q "No symbols, .*$MODULENAME.*" "$OUTPUTFILE"; then
-    MODULEID=$(grep -P "No symbols, .*QGC-Gov.*" "$OUTPUTFILE" | grep -Po "[0-9A-F]{33}")
+    MODULEID=$(grep -P "No symbols, .*$MODULENAME.*" "$OUTPUTFILE" | grep -Po "[0-9A-F]{33}")
     echo "WARNING: No debug symbols found for $MODULENAME with module-id $MODULEID"
 fi
 


### PR DESCRIPTION
This fixes an issue where the script prints nothing (indicating success) when running for apps with a modulename other than "QGC-Gov", which would mislead the user if the decoding in fact did not succeed.

It also adds the ability for the user to specify the modulename as an optional arg, and warns if the modulename is incorrect.